### PR TITLE
fix storybook background color with provider

### DIFF
--- a/.storybook/CustomDocsDecorators.tsx
+++ b/.storybook/CustomDocsDecorators.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect } from 'react'
+import React, { useMemo } from 'react'
 
 import { YourSekaiProvider } from '@/components/provider/YourSekaiProvider'
 
-import { useCreateSekai } from '@/hooks/useCreateSekai'
 import { DARK_MODE, LIGHT_MODE } from '@/hooks/useThemeMode'
 import { createSekai } from '@/utils/createSekai'
 
@@ -25,16 +24,24 @@ export const CustomDocsDecorators = ({ story: Story, context }: CustomDocsDecora
   const isPortal: boolean = context.parameters.portal
   const isPortalDocsPreview = isPortal && isDocs
 
-  const theme = createSekai({
-    palette: {
-      sekai: sekai,
-      mode: isDark ? DARK_MODE : LIGHT_MODE,
-    },
-  })
+  const storySekai = useMemo<ColorsSekaiKey>(() => sekai, [sekai])
+  const storyMode = useMemo<PaletteMode>(() => modeTheme, [modeTheme])
+
+  const sekaiTheme = useMemo(
+    () =>
+      createSekai({
+        palette: {
+          sekai: storySekai,
+          mode: storyMode,
+        },
+      }),
+    [storySekai, storyMode],
+  )
 
   return (
-    <YourSekaiProvider sekaiTheme={theme}>
-      <SekaiThemeSetting sekai={sekai} mode={modeTheme} />
+    <YourSekaiProvider
+      sekaiTheme={sekaiTheme}
+      options={{ disableStoreSekai: true, disableStoreTheme: true }}>
       <Story
         args={{
           ...context.args,
@@ -55,25 +62,4 @@ const getContainerPortalRoot = (context: StoryContext, isDocs: boolean) => {
       ? nodeList[isPrimary ? 0 : 1]?.querySelector('.docs-story')
       : document.getElementById(`anchor--${context.id}`)?.querySelector('.docs-story')
     : document.body
-}
-
-interface SekaiThemeSettingProps {
-  sekai: ColorsSekaiKey
-  mode: PaletteMode
-}
-
-const SekaiThemeSetting = ({ sekai, mode }: SekaiThemeSettingProps) => {
-  const { switchSekaiColor, switchColorTheme } = useCreateSekai()
-
-  useEffect(() => {
-    switchSekaiColor(sekai)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sekai])
-
-  useEffect(() => {
-    switchColorTheme(mode)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode])
-
-  return <></>
 }


### PR DESCRIPTION
<!-- prettier-ignore-start -->
![PR-Header](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc096,100:99ccff&section=header&reversal=false)

### 🌸 作業概要 🌸

<!-- 作業内容を簡単に -->
storybookの背景がproviderの影響で設定値と一致しなくなっていた

### 💫 追加/変更/修正内容 🍀

<!-- 箇条書きでいいので、あとで見返してわかる内容を -->

- Providerがライトモードダークモードの値を保持してしまうため、Storyの期待値と不一致になっていた
- Providerにローカルストレージ保存の有無を設定できるオプションが追加されたので適応した

### 🎤 確認事項 🎪

- [x] branch名はどんな作業を行ったかわかる命名にしたか(ex.20250831_add_readme)
- [ ] Pushする前にビルド行い、distを最新にしたか
- [ ] Dev環境にデプロイしての動作確認実施したか
- [ ] アクセシビリティチェックの実施(ave DevToolsの実施)したか
- [ ] 影響確認を行ったか
- [ ] AIによるレビューの実施を行い、以下の確認をしたか
  - [ ] 指摘事項の妥当性の確認
  - [ ] 根拠の確認・調査
  - [ ] 指摘事項の修正
  - [ ] 再レビューの実施

#### 🎸 AI指摘事項 🎹

<Details><Summary>Review by ClaudeAI and ChatGPT</Summary>

```ts
本PRでは指摘事項なし
```

</Details>

### 💻 評価項目 🆚

<!-- 行った動作確認を箇条書きでも -->

- 

### 🎵 備考 💚 Y(_ﾟ□ﾟ_) < (あれば)

<!-- ちょっとXXに課題が残っている...など何かあれば備忘のためにも -->

![PR-Foorter](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc096,100:99ccff&section=footer&reversal=false)
<!-- prettier-ignore-end -->
