### PR TITLE
Add comprehensive unit tests for Card components

### DIFF
--- a/test/components/card/card.test.tsx
+++ b/test/components/card/card.test.tsx
@@ -1,0 +1,516 @@
+/* eslint-disable max-lines-per-function */
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+
+import { Card, CardContent, CardTitle } from '@/components/card/Card'
+
+import type { CardProps, CardContentProps, CardTitleProps } from '@/components/card/Card'
+
+// === MOCKS ===
+
+jest.mock('@/internal/useOptionalSekai', () => ({
+  useOptionalSekai: jest.fn(() => ({
+    sekaiColor: '#33ccba',
+    modeTheme: 'light',
+    isLight: true,
+  })),
+}))
+
+jest.mock('@/utils/converter', () => ({
+  convertHexToRgba: jest.fn((color: string, alpha: number) => `rgba(51, 204, 186, ${alpha})`),
+}))
+
+// === CARD COMPONENT TESTS ===
+
+describe('Card Component', () => {
+  const defaultProps: CardProps = {
+    children: <div>Card Content</div>,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      render(<Card {...defaultProps} />)
+      expect(screen.getByText('Card Content')).toBeInTheDocument()
+    })
+
+    it('should render children content', () => {
+      render(
+        <Card {...defaultProps}>
+          <span data-testid="child-content">Child Content</span>
+        </Card>,
+      )
+      expect(screen.getByTestId('child-content')).toBeInTheDocument()
+    })
+
+    it('should render with custom id', () => {
+      const { container } = render(<Card {...defaultProps} id="custom-card" />)
+      expect(container.querySelector('#custom-card')).toBeInTheDocument()
+    })
+
+    it('should render with custom className', () => {
+      const { container } = render(<Card {...defaultProps} className="custom-class" />)
+      expect(container.querySelector('.custom-class')).toBeInTheDocument()
+    })
+
+    it('should render with custom styles', () => {
+      const customStyle = { backgroundColor: 'red', padding: '10px' }
+      const { container } = render(<Card {...defaultProps} style={customStyle} />)
+      const element = container.firstChild as HTMLElement
+      expect(element).toHaveStyle('background-color: rgb(255, 0, 0)')
+      expect(element).toHaveStyle('padding: 10px')
+    })
+
+    it('should render complex children', () => {
+      render(
+        <Card {...defaultProps}>
+          <div>First Child</div>
+          <div>Second Child</div>
+        </Card>,
+      )
+      expect(screen.getByText('First Child')).toBeInTheDocument()
+      expect(screen.getByText('Second Child')).toBeInTheDocument()
+    })
+  })
+
+  describe('Theme Integration', () => {
+    beforeEach(() => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#33ccba',
+        modeTheme: 'light',
+        isLight: true,
+      })
+    })
+
+    it('should apply sekai color CSS variables', () => {
+      const { container } = render(<Card {...defaultProps} sekai="Miku" />)
+      const element = container.firstChild as HTMLElement
+      expect(element).toHaveStyle({ '--sekai-color': '#33ccba' })
+    })
+
+    it('should apply sekai color shadow CSS variables', () => {
+      const { container } = render(<Card {...defaultProps} />)
+      const element = container.firstChild as HTMLElement
+      expect(element).toHaveStyle({ '--sekai-color-shadow': 'rgba(51, 204, 186, 0.75)' })
+    })
+
+    it('should call convertHexToRgba with correct alpha', () => {
+      const convertHexToRgba = require('@/utils/converter').convertHexToRgba
+      render(<Card {...defaultProps} />)
+      expect(convertHexToRgba).toHaveBeenCalledWith('#33ccba', 0.75)
+    })
+
+    it('should apply light theme mode class', () => {
+      const { container } = render(<Card {...defaultProps} themeMode="light" />)
+      expect(container.querySelector('[class*="light"]')).toBeTruthy()
+    })
+
+    it('should apply dark theme mode class', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#33ccba',
+        modeTheme: 'dark',
+        isLight: false,
+      })
+
+      const { container } = render(<Card {...defaultProps} themeMode="dark" />)
+      expect(container.querySelector('[class*="dark"]')).toBeTruthy()
+    })
+
+    it('should call useOptionalSekai with correct parameters', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockClear()
+
+      render(<Card {...defaultProps} sekai="Miku" themeMode="light" />)
+
+      expect(useOptionalSekai).toHaveBeenCalledWith({
+        sekai: 'Miku',
+        mode: 'light',
+      })
+    })
+  })
+
+  describe('HTML Attributes', () => {
+    it('should support aria-label attribute', () => {
+      const { container } = render(<Card {...defaultProps} aria-label="Card description" />)
+      const card = container.firstChild as HTMLElement
+      expect(card).toHaveAttribute('aria-label', 'Card description')
+    })
+
+    it('should support data-testid attribute', () => {
+      render(<Card {...defaultProps} data-testid="test-card" />)
+      expect(screen.getByTestId('test-card')).toBeInTheDocument()
+    })
+
+    it('should support role attribute', () => {
+      const { container } = render(<Card {...defaultProps} role="article" />)
+      const card = container.firstChild as HTMLElement
+      expect(card).toHaveAttribute('role', 'article')
+    })
+
+    it('should pass through div props', () => {
+      const handleClick = jest.fn()
+      const { container } = render(<Card {...defaultProps} onClick={handleClick} />)
+      const card = container.firstChild as HTMLElement
+      card.click()
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Custom Styling', () => {
+    it('should merge custom className with default classes', () => {
+      const { container } = render(<Card {...defaultProps} className="custom-card" />)
+      const card = container.firstChild as HTMLElement
+      expect(card).toHaveClass('custom-card')
+    })
+
+    it('should merge custom styles with option styles', () => {
+      const customStyle = { padding: '20px', margin: '10px' }
+      const { container } = render(<Card {...defaultProps} style={customStyle} />)
+      const card = container.firstChild as HTMLElement
+
+      expect(card).toHaveStyle({
+        padding: '20px',
+        margin: '10px',
+      })
+    })
+
+    it('should preserve custom styles alongside sekai color variables', () => {
+      const customStyle = { borderRadius: '8px' }
+      const { container } = render(<Card {...defaultProps} sekai="Miku" style={customStyle} />)
+      const card = container.firstChild as HTMLElement
+
+      expect(card).toHaveStyle({
+        'borderRadius': '8px',
+        '--sekai-color': '#33ccba',
+      })
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle null children', () => {
+      const { container } = render(<Card children={null as unknown as React.ReactNode} />)
+      expect(container.firstChild).toBeInTheDocument()
+    })
+
+    it('should handle multiple nested children', () => {
+      render(
+        <Card {...defaultProps}>
+          <div>
+            <span>Nested Level 1</span>
+            <div>
+              <span>Nested Level 2</span>
+            </div>
+          </div>
+        </Card>,
+      )
+      expect(screen.getByText('Nested Level 1')).toBeInTheDocument()
+      expect(screen.getByText('Nested Level 2')).toBeInTheDocument()
+    })
+  })
+
+  describe('Integration Tests', () => {
+    it('should update on re-render', () => {
+      const { rerender } = render(<Card {...defaultProps}>Original</Card>)
+      expect(screen.getByText('Original')).toBeInTheDocument()
+
+      rerender(<Card {...defaultProps}>Updated</Card>)
+      expect(screen.getByText('Updated')).toBeInTheDocument()
+      expect(screen.queryByText('Original')).not.toBeInTheDocument()
+    })
+
+    it('should update sekai color on re-render', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#33ccba',
+        modeTheme: 'light',
+        isLight: true,
+      })
+
+      const { rerender, container } = render(<Card {...defaultProps} sekai="Miku" />)
+      let card = container.firstChild as HTMLElement
+      expect(card).toHaveStyle({ '--sekai-color': '#33ccba' })
+
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#ff6699',
+        modeTheme: 'light',
+        isLight: true,
+      })
+
+      rerender(<Card {...defaultProps} sekai="Ichika" />)
+      card = container.firstChild as HTMLElement
+      expect(card).toHaveStyle({ '--sekai-color': '#ff6699' })
+    })
+  })
+})
+
+// === CARD CONTENT COMPONENT TESTS ===
+
+describe('CardContent Component', () => {
+  const defaultProps: CardContentProps = {
+    children: <div>Content</div>,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      render(<CardContent {...defaultProps} />)
+      expect(screen.getByText('Content')).toBeInTheDocument()
+    })
+
+    it('should render children content', () => {
+      render(
+        <CardContent {...defaultProps}>
+          <span data-testid="child-content">Child Content</span>
+        </CardContent>,
+      )
+      expect(screen.getByTestId('child-content')).toBeInTheDocument()
+    })
+
+    it('should render with custom id', () => {
+      const { container } = render(<CardContent {...defaultProps} id="custom-content" />)
+      expect(container.querySelector('#custom-content')).toBeInTheDocument()
+    })
+
+    it('should render with custom className', () => {
+      const { container } = render(<CardContent {...defaultProps} className="custom-class" />)
+      expect(container.querySelector('.custom-class')).toBeInTheDocument()
+    })
+
+    it('should render with custom styles', () => {
+      const customStyle = { backgroundColor: 'blue', padding: '15px' }
+      const { container } = render(<CardContent {...defaultProps} style={customStyle} />)
+      const element = container.firstChild as HTMLElement
+      expect(element).toHaveStyle('background-color: rgb(0, 0, 255)')
+      expect(element).toHaveStyle('padding: 15px')
+    })
+  })
+
+  describe('Theme Integration', () => {
+    it('should apply light theme mode class', () => {
+      const { container } = render(<CardContent {...defaultProps} themeMode="light" />)
+      expect(container.querySelector('[class*="light"]')).toBeTruthy()
+    })
+
+    it('should apply dark theme mode class', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#33ccba',
+        modeTheme: 'dark',
+        isLight: false,
+      })
+
+      const { container } = render(<CardContent {...defaultProps} themeMode="dark" />)
+      expect(container.querySelector('[class*="dark"]')).toBeTruthy()
+    })
+
+    it('should call useOptionalSekai with correct parameters', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockClear()
+
+      render(<CardContent {...defaultProps} themeMode="light" />)
+
+      expect(useOptionalSekai).toHaveBeenCalledWith({
+        mode: 'light',
+      })
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle null children', () => {
+      const { container } = render(
+        <CardContent children={null as unknown as React.ReactNode} />,
+      )
+      expect(container.firstChild).toBeInTheDocument()
+    })
+
+    it('should handle undefined id', () => {
+      const { container } = render(<CardContent {...defaultProps} id={undefined} />)
+      expect(container.firstChild).not.toHaveAttribute('id')
+    })
+  })
+
+  describe('Integration Tests', () => {
+    it('should update on re-render', () => {
+      const { rerender } = render(<CardContent {...defaultProps}>Original</CardContent>)
+      expect(screen.getByText('Original')).toBeInTheDocument()
+
+      rerender(<CardContent {...defaultProps}>Updated</CardContent>)
+      expect(screen.getByText('Updated')).toBeInTheDocument()
+    })
+  })
+})
+
+// === CARD TITLE COMPONENT TESTS ===
+
+describe('CardTitle Component', () => {
+  const defaultProps: CardTitleProps = {
+    title: 'Card Title',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      render(<CardTitle {...defaultProps} />)
+      expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument()
+    })
+
+    it('should render title text', () => {
+      render(<CardTitle {...defaultProps} title="Test Title" />)
+      expect(screen.getByText('Test Title')).toBeInTheDocument()
+    })
+
+    it('should render with custom id', () => {
+      const { container } = render(<CardTitle {...defaultProps} id="custom-title" />)
+      expect(container.querySelector('#custom-title')).toBeInTheDocument()
+    })
+
+    it('should render with custom className', () => {
+      const { container } = render(<CardTitle {...defaultProps} className="custom-class" />)
+      expect(container.querySelector('.custom-class')).toBeInTheDocument()
+    })
+
+    it('should render with custom styles', () => {
+      const customStyle = { color: 'red', fontSize: '24px' }
+      const { container } = render(<CardTitle {...defaultProps} style={customStyle} />)
+      const element = container.firstChild as HTMLElement
+      expect(element).toHaveStyle('color: rgb(255, 0, 0)')
+      expect(element).toHaveStyle('font-size: 24px')
+    })
+
+    it('should render as h3 element', () => {
+      render(<CardTitle {...defaultProps} />)
+      const heading = screen.getByRole('heading', { level: 3 })
+      expect(heading.tagName).toBe('H3')
+    })
+  })
+
+  describe('Underline Prop', () => {
+    it('should apply underline class when underline is true', () => {
+      const { container } = render(<CardTitle {...defaultProps} underline={true} />)
+      expect(container.querySelector('[class*="underline"]')).toBeTruthy()
+    })
+
+    it('should not apply underline class when underline is undefined', () => {
+      const { container } = render(<CardTitle {...defaultProps} />)
+      expect(container.querySelector('[class*="underline"]')).toBeFalsy()
+    })
+  })
+
+  describe('Theme Integration', () => {
+    beforeEach(() => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#33ccba',
+        modeTheme: 'light',
+        isLight: true,
+      })
+    })
+
+    it('should apply sekai color CSS variables', () => {
+      const { container } = render(<CardTitle {...defaultProps} sekai="Miku" />)
+      const element = container.firstChild as HTMLElement
+      expect(element).toHaveStyle({ '--sekai-color': '#33ccba' })
+    })
+
+    it('should apply light theme mode class', () => {
+      const { container } = render(<CardTitle {...defaultProps} themeMode="light" />)
+      expect(container.querySelector('[class*="light"]')).toBeTruthy()
+    })
+
+    it('should apply dark theme mode class', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#33ccba',
+        modeTheme: 'dark',
+        isLight: false,
+      })
+
+      const { container } = render(<CardTitle {...defaultProps} themeMode="dark" />)
+      expect(container.querySelector('[class*="dark"]')).toBeTruthy()
+    })
+
+    it('should call useOptionalSekai with correct parameters', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockClear()
+
+      render(<CardTitle {...defaultProps} sekai="Miku" themeMode="light" />)
+
+      expect(useOptionalSekai).toHaveBeenCalledWith({
+        sekai: 'Miku',
+        mode: 'light',
+      })
+    })
+  })
+
+  describe('Custom Styling', () => {
+    it('should merge custom className with default classes', () => {
+      const { container } = render(<CardTitle {...defaultProps} className="custom-title" />)
+      const title = container.firstChild as HTMLElement
+      expect(title).toHaveClass('custom-title')
+    })
+
+    it('should preserve custom styles alongside sekai color variables', () => {
+      const customStyle = { fontWeight: 'bold' }
+      const { container } = render(
+        <CardTitle {...defaultProps} sekai="Miku" style={customStyle} />,
+      )
+      const title = container.firstChild as HTMLElement
+
+      expect(title).toHaveStyle({
+        'fontWeight': 'bold',
+        '--sekai-color': '#33ccba',
+      })
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty title', () => {
+      render(<CardTitle {...defaultProps} title="" />)
+      const heading = screen.getByRole('heading', { level: 3 })
+      expect(heading).toBeInTheDocument()
+      expect(heading).toHaveTextContent('')
+    })
+
+    it('should handle very long title', () => {
+      const longTitle = 'A'.repeat(500)
+      render(<CardTitle {...defaultProps} title={longTitle} />)
+      expect(screen.getByText(longTitle)).toBeInTheDocument()
+    })
+
+    it('should handle special characters in title', () => {
+      render(<CardTitle {...defaultProps} title={'<>&"\'`'} />)
+      expect(screen.getByText('<>&"\'`')).toBeInTheDocument()
+    })
+  })
+
+  describe('Integration Tests', () => {
+    it('should update title on re-render', () => {
+      const { rerender } = render(<CardTitle {...defaultProps} title="Original" />)
+      expect(screen.getByText('Original')).toBeInTheDocument()
+
+      rerender(<CardTitle {...defaultProps} title="Updated" />)
+      expect(screen.getByText('Updated')).toBeInTheDocument()
+      expect(screen.queryByText('Original')).not.toBeInTheDocument()
+    })
+
+    it('should update underline state on re-render', () => {
+      const { rerender, container } = render(<CardTitle {...defaultProps} />)
+      expect(container.querySelector('[class*="underline"]')).toBeFalsy()
+
+      rerender(<CardTitle {...defaultProps} underline={true} />)
+      expect(container.querySelector('[class*="underline"]')).toBeTruthy()
+    })
+  })
+})

--- a/test/components/card/musicBannerCard.test.tsx
+++ b/test/components/card/musicBannerCard.test.tsx
@@ -1,0 +1,416 @@
+/* eslint-disable max-lines-per-function */
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { MusicBannerCard } from '@/components/card/MusicBannerCard'
+
+import type { MusicBannerCardProps } from '@/components/card/MusicBannerCard'
+
+// === MOCKS ===
+
+jest.mock('@/internal/useOptionalSekai', () => ({
+  useOptionalSekai: jest.fn(() => ({
+    sekaiColor: '#33ccba',
+    modeTheme: 'light',
+    isLight: true,
+  })),
+}))
+
+jest.mock('@/utils/converter', () => ({
+  convertHexToRgba: jest.fn((color: string, alpha: number) => `rgba(51, 204, 186, ${alpha})`),
+}))
+
+// Mock SVG icons
+jest.mock('@/img/compactDisc', () => ({
+  CompactDiscIcon: ({ className }: { className?: string }) => (
+    <svg data-testid="compact-disc-icon" className={className} />
+  ),
+}))
+
+jest.mock('@/img/equalizer', () => ({
+  EqualizerIcon: ({ className }: { className?: string }) => (
+    <svg data-testid="equalizer-icon" className={className} />
+  ),
+}))
+
+// Mock MarqueeText component
+jest.mock('@/components/text/MarqueeText', () => ({
+  MarqueeText: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="marquee-text" className={className}>
+      {children}
+    </div>
+  ),
+}))
+
+// === TEST SUITE ===
+
+describe('MusicBannerCard Component', () => {
+  const defaultProps: MusicBannerCardProps = {
+    musicTitle: 'Test Song',
+    artist: 'Test Artist',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      render(<MusicBannerCard {...defaultProps} />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should render music title', () => {
+      render(<MusicBannerCard {...defaultProps} musicTitle="Amazing Song" />)
+      expect(screen.getByText('Amazing Song')).toBeInTheDocument()
+    })
+
+    it('should render artist name', () => {
+      render(<MusicBannerCard {...defaultProps} artist="Famous Artist" />)
+      expect(screen.getByText('Famous Artist')).toBeInTheDocument()
+    })
+
+    it('should render with custom id', () => {
+      const { container } = render(<MusicBannerCard {...defaultProps} id="custom-music-card" />)
+      expect(container.querySelector('#custom-music-card')).toBeInTheDocument()
+    })
+
+    it('should render with custom className', () => {
+      const { container } = render(<MusicBannerCard {...defaultProps} className="custom-class" />)
+      expect(container.querySelector('.custom-class')).toBeInTheDocument()
+    })
+
+    it('should render with custom styles', () => {
+      const customStyle = { backgroundColor: 'red' }
+      const { container } = render(<MusicBannerCard {...defaultProps} style={customStyle} />)
+      const element = container.firstChild as HTMLElement
+      expect(element).toHaveStyle('background-color: rgb(255, 0, 0)')
+    })
+
+    it('should render icons', () => {
+      render(<MusicBannerCard {...defaultProps} />)
+      expect(screen.getByTestId('compact-disc-icon')).toBeInTheDocument()
+      expect(screen.getByTestId('equalizer-icon')).toBeInTheDocument()
+    })
+
+    it('should have role="button"', () => {
+      render(<MusicBannerCard {...defaultProps} />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should have tabIndex=0 for keyboard accessibility', () => {
+      render(<MusicBannerCard {...defaultProps} />)
+      const card = screen.getByRole('button')
+      expect(card).toHaveAttribute('tabIndex', '0')
+    })
+  })
+
+  describe('Selected State', () => {
+    it('should not be selected by default', () => {
+      const { container } = render(<MusicBannerCard {...defaultProps} />)
+      expect(container.querySelector('[class*="selected"]')).toBeFalsy()
+    })
+
+    it('should be selected when selected prop is true', () => {
+      const { container } = render(<MusicBannerCard {...defaultProps} selected={true} />)
+      expect(container.querySelector('[class*="selected"]')).toBeTruthy()
+    })
+
+    it('should not be selected when selected prop is false', () => {
+      const { container } = render(<MusicBannerCard {...defaultProps} selected={false} />)
+      expect(container.querySelector('[class*="selected"]')).toBeFalsy()
+    })
+
+    it('should update selected state when prop changes', () => {
+      const { container, rerender } = render(
+        <MusicBannerCard {...defaultProps} selected={false} />,
+      )
+      expect(container.querySelector('[class*="selected"]')).toBeFalsy()
+
+      rerender(<MusicBannerCard {...defaultProps} selected={true} />)
+      expect(container.querySelector('[class*="selected"]')).toBeTruthy()
+    })
+  })
+
+  describe('Focus and Hover Interactions', () => {
+    it('should become selected on focus', async () => {
+      const user = userEvent.setup()
+      const onSelect = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onSelect={onSelect} />)
+
+      const card = screen.getByRole('button')
+      await user.tab()
+      expect(card).toHaveFocus()
+      expect(onSelect).toHaveBeenCalledWith(true)
+    })
+
+    it('should become selected on mouse enter', async () => {
+      const user = userEvent.setup()
+      const onSelect = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onSelect={onSelect} />)
+
+      const card = screen.getByRole('button')
+      await user.hover(card)
+      expect(onSelect).toHaveBeenCalledWith(true)
+    })
+
+    it('should call onBlur when blurred', async () => {
+      const user = userEvent.setup()
+      const onBlur = jest.fn()
+      render(
+        <>
+          <MusicBannerCard {...defaultProps} onBlur={onBlur} />
+          <button>Other Button</button>
+        </>,
+      )
+
+      const card = screen.getByRole('button', { name: /test song/i })
+      await user.tab()
+      expect(card).toHaveFocus()
+
+      await user.tab()
+      expect(onBlur).toHaveBeenCalled()
+    })
+
+    it('should call onMouseLeave when mouse leaves', async () => {
+      const user = userEvent.setup()
+      const onMouseLeave = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onMouseLeave={onMouseLeave} />)
+
+      const card = screen.getByRole('button')
+      await user.hover(card)
+      await user.unhover(card)
+      expect(onMouseLeave).toHaveBeenCalled()
+    })
+  })
+
+  describe('Click Handling', () => {
+    it('should call onClick when clicked', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onClick={handleClick} />)
+
+      const card = screen.getByRole('button')
+      await user.click(card)
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should handle multiple clicks', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onClick={handleClick} />)
+
+      const card = screen.getByRole('button')
+      await user.click(card)
+      await user.click(card)
+      await user.click(card)
+      expect(handleClick).toHaveBeenCalledTimes(3)
+    })
+
+    it('should work without onClick handler', async () => {
+      const user = userEvent.setup()
+      render(<MusicBannerCard {...defaultProps} />)
+
+      const card = screen.getByRole('button')
+      await expect(user.click(card)).resolves.not.toThrow()
+    })
+  })
+
+  describe('Keyboard Navigation', () => {
+    it('should activate with Enter key when onClick is provided', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onClick={handleClick} />)
+
+      const card = screen.getByRole('button')
+      await user.tab()
+      expect(card).toHaveFocus()
+
+      await user.keyboard('{Enter}')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should be focusable with Tab key', async () => {
+      const user = userEvent.setup()
+      render(<MusicBannerCard {...defaultProps} />)
+
+      const card = screen.getByRole('button')
+      await user.tab()
+      expect(card).toHaveFocus()
+    })
+  })
+
+  describe('Variants', () => {
+    it('should use default variant by default', () => {
+      const { container } = render(<MusicBannerCard {...defaultProps} />)
+      expect(container.firstChild).toBeInTheDocument()
+    })
+
+    it('should apply view-all variant', () => {
+      const { container } = render(<MusicBannerCard {...defaultProps} variants="view-all" />)
+      expect(container.firstChild).toBeInTheDocument()
+    })
+  })
+
+  describe('Theme Integration', () => {
+    beforeEach(() => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#33ccba',
+        modeTheme: 'light',
+        isLight: true,
+      })
+    })
+
+    it('should pass sekai prop to Card', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockClear()
+
+      render(<MusicBannerCard {...defaultProps} sekai="Miku" />)
+      expect(useOptionalSekai).toHaveBeenCalled()
+    })
+
+    it('should pass themeMode prop to Card', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockClear()
+
+      render(<MusicBannerCard {...defaultProps} themeMode="light" />)
+      expect(useOptionalSekai).toHaveBeenCalled()
+    })
+  })
+
+  describe('onSelect Callback', () => {
+    it('should call onSelect with true when focused', async () => {
+      const user = userEvent.setup()
+      const onSelect = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onSelect={onSelect} />)
+
+      await user.tab()
+      expect(onSelect).toHaveBeenCalledWith(true)
+    })
+
+    it('should call onSelect with true when mouse enters', async () => {
+      const user = userEvent.setup()
+      const onSelect = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onSelect={onSelect} />)
+
+      const card = screen.getByRole('button')
+      await user.hover(card)
+      expect(onSelect).toHaveBeenCalledWith(true)
+    })
+
+    it('should work without onSelect handler', async () => {
+      const user = userEvent.setup()
+      render(<MusicBannerCard {...defaultProps} />)
+
+      const card = screen.getByRole('button')
+      await expect(user.hover(card)).resolves.not.toThrow()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty musicTitle', () => {
+      render(<MusicBannerCard {...defaultProps} musicTitle="" />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should handle empty artist', () => {
+      render(<MusicBannerCard {...defaultProps} artist="" />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should handle very long musicTitle', () => {
+      const longTitle = 'A'.repeat(500)
+      render(<MusicBannerCard {...defaultProps} musicTitle={longTitle} />)
+      expect(screen.getByText(longTitle)).toBeInTheDocument()
+    })
+
+    it('should handle very long artist name', () => {
+      const longArtist = 'B'.repeat(500)
+      render(<MusicBannerCard {...defaultProps} artist={longArtist} />)
+      expect(screen.getByText(longArtist)).toBeInTheDocument()
+    })
+
+    it('should handle special characters in musicTitle', () => {
+      render(<MusicBannerCard {...defaultProps} musicTitle={'<>&"\'`'} />)
+      expect(screen.getByText('<>&"\'`')).toBeInTheDocument()
+    })
+
+    it('should handle special characters in artist', () => {
+      render(<MusicBannerCard {...defaultProps} artist={'<>&"\'`'} />)
+      expect(screen.getByText('<>&"\'`')).toBeInTheDocument()
+    })
+  })
+
+  describe('Integration Tests', () => {
+    it('should update musicTitle on re-render', () => {
+      const { rerender } = render(<MusicBannerCard {...defaultProps} musicTitle="Original" />)
+      expect(screen.getByText('Original')).toBeInTheDocument()
+
+      rerender(<MusicBannerCard {...defaultProps} musicTitle="Updated" />)
+      expect(screen.getByText('Updated')).toBeInTheDocument()
+      expect(screen.queryByText('Original')).not.toBeInTheDocument()
+    })
+
+    it('should update artist on re-render', () => {
+      const { rerender } = render(<MusicBannerCard {...defaultProps} artist="Original Artist" />)
+      expect(screen.getByText('Original Artist')).toBeInTheDocument()
+
+      rerender(<MusicBannerCard {...defaultProps} artist="Updated Artist" />)
+      expect(screen.getByText('Updated Artist')).toBeInTheDocument()
+    })
+
+    it('should handle rapid interactions', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      const onSelect = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onClick={handleClick} onSelect={onSelect} />)
+
+      const card = screen.getByRole('button')
+
+      await user.click(card)
+      await user.click(card)
+      await user.click(card)
+
+      expect(handleClick).toHaveBeenCalledTimes(3)
+    })
+
+    it('should maintain state across re-renders', () => {
+      const { rerender, container } = render(
+        <MusicBannerCard {...defaultProps} selected={true} />,
+      )
+      expect(container.querySelector('[class*="selected"]')).toBeTruthy()
+
+      rerender(<MusicBannerCard {...defaultProps} selected={true} />)
+      expect(container.querySelector('[class*="selected"]')).toBeTruthy()
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have button role', () => {
+      render(<MusicBannerCard {...defaultProps} />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should be keyboard accessible', async () => {
+      const user = userEvent.setup()
+      render(<MusicBannerCard {...defaultProps} />)
+
+      const card = screen.getByRole('button')
+      await user.tab()
+      expect(card).toHaveFocus()
+    })
+
+    it('should support Enter key activation', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<MusicBannerCard {...defaultProps} onClick={handleClick} />)
+
+      await user.tab()
+      await user.keyboard('{Enter}')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/test/components/card/prskLinkCard.test.tsx
+++ b/test/components/card/prskLinkCard.test.tsx
@@ -1,0 +1,445 @@
+/* eslint-disable max-lines-per-function */
+import React from 'react'
+
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { PrskLinkCard } from '@/components/card/PrskLinkCard'
+
+import type { PrskLinkCardProps } from '@/components/card/PrskLinkCard'
+
+// === MOCKS ===
+
+jest.mock('@/internal/useOptionalSekai', () => ({
+  useOptionalSekai: jest.fn(() => ({
+    sekaiColor: '#33ccba',
+    modeTheme: 'light',
+    isLight: true,
+  })),
+}))
+
+jest.mock('@/utils/converter', () => ({
+  convertHexToRgba: jest.fn((color: string, alpha: number) => `rgba(51, 204, 186, ${alpha})`),
+}))
+
+// Mock NamePlate component
+jest.mock('@/components/text/NamePlate', () => ({
+  NamePlate: ({
+    text,
+    id,
+    className,
+  }: {
+    text: string
+    id?: string
+    className?: string
+  }) => (
+    <div data-testid="name-plate" id={id} className={className}>
+      {text}
+    </div>
+  ),
+}))
+
+// Mock OutlineText component
+jest.mock('@/components/text/OutlineText', () => ({
+  OutlineText: ({
+    text,
+    id,
+    className,
+  }: {
+    text: string
+    id?: string
+    className?: string
+  }) => (
+    <div data-testid="outline-text" id={id} className={className}>
+      {text}
+    </div>
+  ),
+}))
+
+// === TEST SUITE ===
+
+describe('PrskLinkCard Component', () => {
+  const defaultProps: PrskLinkCardProps = {
+    title: 'Test Title',
+    subText: 'Test SubText',
+    icon: 'https://example.com/icon.png',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Rendering', () => {
+    it('should render without crashing', () => {
+      render(<PrskLinkCard {...defaultProps} />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should render title text', () => {
+      render(<PrskLinkCard {...defaultProps} title="Card Title" />)
+      expect(screen.getByText('Card Title')).toBeInTheDocument()
+    })
+
+    it('should render subText', () => {
+      render(<PrskLinkCard {...defaultProps} subText="Card SubText" />)
+      expect(screen.getByText('Card SubText')).toBeInTheDocument()
+    })
+
+    it('should render with custom id', () => {
+      const { container } = render(<PrskLinkCard {...defaultProps} id="custom-prsk-card" />)
+      expect(container.querySelector('#custom-prsk-card')).toBeInTheDocument()
+    })
+
+    it('should render with custom className', () => {
+      const { container } = render(<PrskLinkCard {...defaultProps} className="custom-class" />)
+      expect(container.querySelector('.custom-class')).toBeInTheDocument()
+    })
+
+    it('should render with custom styles', () => {
+      const customStyle = { backgroundColor: 'blue' }
+      const { container } = render(<PrskLinkCard {...defaultProps} style={customStyle} />)
+      const element = container.firstChild as HTMLElement
+      expect(element).toHaveStyle('background-color: rgb(0, 0, 255)')
+    })
+
+    it('should render NamePlate component', () => {
+      render(<PrskLinkCard {...defaultProps} />)
+      expect(screen.getByTestId('name-plate')).toBeInTheDocument()
+    })
+
+    it('should render OutlineText component', () => {
+      render(<PrskLinkCard {...defaultProps} />)
+      expect(screen.getByTestId('outline-text')).toBeInTheDocument()
+    })
+  })
+
+  describe('Icon Rendering', () => {
+    it('should render img element when icon is a string URL', () => {
+      const { container } = render(
+        <PrskLinkCard {...defaultProps} icon="https://example.com/icon.png" />,
+      )
+      const img = container.querySelector('img')
+      expect(img).toBeInTheDocument()
+      expect(img).toHaveAttribute('src', 'https://example.com/icon.png')
+    })
+
+    it('should render img with empty alt attribute', () => {
+      const { container } = render(
+        <PrskLinkCard {...defaultProps} icon="https://example.com/icon.png" />,
+      )
+      const img = container.querySelector('img')
+      expect(img).toHaveAttribute('alt', '')
+    })
+
+    it('should render React node when icon is not a string', () => {
+      const iconNode = <svg data-testid="custom-svg-icon" />
+      render(<PrskLinkCard {...defaultProps} icon={iconNode} />)
+      expect(screen.getByTestId('custom-svg-icon')).toBeInTheDocument()
+    })
+
+    it('should render complex React node as icon', () => {
+      const iconNode = (
+        <div data-testid="complex-icon">
+          <span>Icon Content</span>
+        </div>
+      )
+      render(<PrskLinkCard {...defaultProps} icon={iconNode} />)
+      expect(screen.getByTestId('complex-icon')).toBeInTheDocument()
+      expect(screen.getByText('Icon Content')).toBeInTheDocument()
+    })
+  })
+
+  describe('Size Props', () => {
+    it('should use default height of 72px', () => {
+      render(<PrskLinkCard {...defaultProps} />)
+      const button = screen.getByRole('button')
+      expect(button).toHaveStyle({ height: '72px' })
+    })
+
+    it('should use default width of 160px', () => {
+      render(<PrskLinkCard {...defaultProps} />)
+      const button = screen.getByRole('button')
+      expect(button).toHaveStyle({ width: '160px' })
+    })
+
+    it('should apply custom height', () => {
+      render(<PrskLinkCard {...defaultProps} height={100} />)
+      const button = screen.getByRole('button')
+      expect(button).toHaveStyle({ height: '100px' })
+    })
+
+    it('should apply custom width', () => {
+      render(<PrskLinkCard {...defaultProps} width={200} />)
+      const button = screen.getByRole('button')
+      expect(button).toHaveStyle({ width: '200px' })
+    })
+
+    it('should apply both custom height and width', () => {
+      render(<PrskLinkCard {...defaultProps} height={150} width={250} />)
+      const button = screen.getByRole('button')
+      expect(button).toHaveStyle({ height: '150px', width: '250px' })
+    })
+  })
+
+  describe('Click Handling', () => {
+    it('should call onClick when button is clicked', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<PrskLinkCard {...defaultProps} onClick={handleClick} />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should handle multiple clicks', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<PrskLinkCard {...defaultProps} onClick={handleClick} />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+      await user.click(button)
+      await user.click(button)
+      expect(handleClick).toHaveBeenCalledTimes(3)
+    })
+
+    it('should work without onClick handler', async () => {
+      const user = userEvent.setup()
+      render(<PrskLinkCard {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+      await expect(user.click(button)).resolves.not.toThrow()
+    })
+  })
+
+  describe('Theme Integration', () => {
+    beforeEach(() => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#33ccba',
+        modeTheme: 'light',
+        isLight: true,
+      })
+    })
+
+    it('should call useOptionalSekai with correct parameters', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockClear()
+
+      render(<PrskLinkCard {...defaultProps} sekai="Miku" themeMode="light" />)
+
+      expect(useOptionalSekai).toHaveBeenCalledWith({
+        sekai: 'Miku',
+        mode: 'light',
+      })
+    })
+
+    it('should apply light theme mode class to button', () => {
+      const { container } = render(<PrskLinkCard {...defaultProps} themeMode="light" />)
+      const button = container.querySelector('button')
+      expect(button?.className).toContain('light')
+    })
+
+    it('should apply dark theme mode class to button', () => {
+      const useOptionalSekai = require('@/internal/useOptionalSekai').useOptionalSekai
+      useOptionalSekai.mockReturnValue({
+        sekaiColor: '#33ccba',
+        modeTheme: 'dark',
+        isLight: false,
+      })
+
+      const { container } = render(<PrskLinkCard {...defaultProps} themeMode="dark" />)
+      const button = container.querySelector('button')
+      expect(button?.className).toContain('dark')
+    })
+  })
+
+  describe('ID Generation', () => {
+    it('should generate title id from provided id', () => {
+      render(<PrskLinkCard {...defaultProps} id="my-card" />)
+      const namePlate = screen.getByTestId('name-plate')
+      expect(namePlate).toHaveAttribute('id', 'my-card-title')
+    })
+
+    it('should generate subtext id from provided id', () => {
+      render(<PrskLinkCard {...defaultProps} id="my-card" />)
+      const outlineText = screen.getByTestId('outline-text')
+      expect(outlineText).toHaveAttribute('id', 'my-card-subtext')
+    })
+
+    it('should use default id when id is not provided', () => {
+      render(<PrskLinkCard {...defaultProps} />)
+      const namePlate = screen.getByTestId('name-plate')
+      expect(namePlate).toHaveAttribute('id', 'prsk-link-card-title')
+    })
+  })
+
+  describe('Accessibility', () => {
+    it('should have button role', () => {
+      render(<PrskLinkCard {...defaultProps} />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should be keyboard accessible', async () => {
+      const user = userEvent.setup()
+      render(<PrskLinkCard {...defaultProps} />)
+
+      const button = screen.getByRole('button')
+      await user.tab()
+      expect(button).toHaveFocus()
+    })
+
+    it('should support Enter key activation', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<PrskLinkCard {...defaultProps} onClick={handleClick} />)
+
+      await user.tab()
+      await user.keyboard('{Enter}')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('should support Space key activation', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<PrskLinkCard {...defaultProps} onClick={handleClick} />)
+
+      await user.tab()
+      await user.keyboard(' ')
+      expect(handleClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle empty title', () => {
+      render(<PrskLinkCard {...defaultProps} title="" />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should handle empty subText', () => {
+      render(<PrskLinkCard {...defaultProps} subText="" />)
+      expect(screen.getByRole('button')).toBeInTheDocument()
+    })
+
+    it('should handle very long title', () => {
+      const longTitle = 'A'.repeat(500)
+      render(<PrskLinkCard {...defaultProps} title={longTitle} />)
+      expect(screen.getByText(longTitle)).toBeInTheDocument()
+    })
+
+    it('should handle very long subText', () => {
+      const longSubText = 'B'.repeat(500)
+      render(<PrskLinkCard {...defaultProps} subText={longSubText} />)
+      expect(screen.getByText(longSubText)).toBeInTheDocument()
+    })
+
+    it('should handle special characters in title', () => {
+      render(<PrskLinkCard {...defaultProps} title={'<>&"\'`'} />)
+      expect(screen.getByText('<>&"\'`')).toBeInTheDocument()
+    })
+
+    it('should handle special characters in subText', () => {
+      render(<PrskLinkCard {...defaultProps} subText={'<>&"\'`'} />)
+      expect(screen.getByText('<>&"\'`')).toBeInTheDocument()
+    })
+
+    it('should handle height of 0', () => {
+      render(<PrskLinkCard {...defaultProps} height={0} />)
+      const button = screen.getByRole('button')
+      expect(button).toHaveStyle({ height: '0px' })
+    })
+
+    it('should handle width of 0', () => {
+      render(<PrskLinkCard {...defaultProps} width={0} />)
+      const button = screen.getByRole('button')
+      expect(button).toHaveStyle({ width: '0px' })
+    })
+  })
+
+  describe('Integration Tests', () => {
+    it('should update title on re-render', () => {
+      const { rerender } = render(<PrskLinkCard {...defaultProps} title="Original" />)
+      expect(screen.getByText('Original')).toBeInTheDocument()
+
+      rerender(<PrskLinkCard {...defaultProps} title="Updated" />)
+      expect(screen.getByText('Updated')).toBeInTheDocument()
+      expect(screen.queryByText('Original')).not.toBeInTheDocument()
+    })
+
+    it('should update subText on re-render', () => {
+      const { rerender } = render(<PrskLinkCard {...defaultProps} subText="Original Sub" />)
+      expect(screen.getByText('Original Sub')).toBeInTheDocument()
+
+      rerender(<PrskLinkCard {...defaultProps} subText="Updated Sub" />)
+      expect(screen.getByText('Updated Sub')).toBeInTheDocument()
+    })
+
+    it('should update icon on re-render', () => {
+      const { rerender, container } = render(
+        <PrskLinkCard {...defaultProps} icon="https://example.com/icon1.png" />,
+      )
+      let img = container.querySelector('img')
+      expect(img).toHaveAttribute('src', 'https://example.com/icon1.png')
+
+      rerender(<PrskLinkCard {...defaultProps} icon="https://example.com/icon2.png" />)
+      img = container.querySelector('img')
+      expect(img).toHaveAttribute('src', 'https://example.com/icon2.png')
+    })
+
+    it('should update size on re-render', () => {
+      const { rerender } = render(<PrskLinkCard {...defaultProps} height={72} width={160} />)
+      let button = screen.getByRole('button')
+      expect(button).toHaveStyle({ height: '72px', width: '160px' })
+
+      rerender(<PrskLinkCard {...defaultProps} height={100} width={200} />)
+      button = screen.getByRole('button')
+      expect(button).toHaveStyle({ height: '100px', width: '200px' })
+    })
+
+    it('should handle rapid clicks', async () => {
+      const user = userEvent.setup()
+      const handleClick = jest.fn()
+      render(<PrskLinkCard {...defaultProps} onClick={handleClick} />)
+
+      const button = screen.getByRole('button')
+      await user.click(button)
+      await user.click(button)
+      await user.click(button)
+      await user.click(button)
+      await user.click(button)
+
+      expect(handleClick).toHaveBeenCalledTimes(5)
+    })
+
+    it('should switch from string icon to React node icon', () => {
+      const { rerender, container } = render(
+        <PrskLinkCard {...defaultProps} icon="https://example.com/icon.png" />,
+      )
+      expect(container.querySelector('img')).toBeInTheDocument()
+
+      rerender(<PrskLinkCard {...defaultProps} icon={<svg data-testid="svg-icon" />} />)
+      expect(container.querySelector('img')).not.toBeInTheDocument()
+      expect(screen.getByTestId('svg-icon')).toBeInTheDocument()
+    })
+  })
+
+  describe('Custom Styling', () => {
+    it('should merge custom className with default classes', () => {
+      const { container } = render(<PrskLinkCard {...defaultProps} className="custom-card" />)
+      const card = container.firstChild as HTMLElement
+      expect(card).toHaveClass('custom-card')
+    })
+
+    it('should merge custom styles with default styles', () => {
+      const customStyle = { padding: '20px', margin: '10px' }
+      const { container } = render(<PrskLinkCard {...defaultProps} style={customStyle} />)
+      const card = container.firstChild as HTMLElement
+
+      expect(card).toHaveStyle({
+        padding: '20px',
+        margin: '10px',
+      })
+    })
+  })
+})


### PR DESCRIPTION
<!-- prettier-ignore-start -->
![PR-Header](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc096,100:99ccff&section=header&reversal=false)

### 🌸 作業概要 🌸

<!-- 作業内容を簡単に -->
Test coverage for Card, CardContent, CardTitle, MusicBannerCard, and PrskLinkCard components including rendering, theme integration, accessibility, and edge cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### 💫 追加/変更/修正内容 🍀

<!-- 箇条書きでいいので、あとで見返してわかる内容を -->

- Cardコンポーネント群の単体テストを作成してもらった

### 🎤 確認事項 🎪

- [x] branch名はどんな作業を行ったかわかる命名にしたか(ex.20250831_add_readme)
- [ ] Pushする前にビルド行い、distを最新にしたか
- [ ] Dev環境にデプロイしての動作確認実施したか
- [ ] アクセシビリティチェックの実施(ave DevToolsの実施)したか
- [ ] 影響確認を行ったか
- [ ] AIによるレビューの実施を行い、以下の確認をしたか
  - [ ] 指摘事項の妥当性の確認
  - [ ] 根拠の確認・調査
  - [ ] 指摘事項の修正
  - [ ] 再レビューの実施

#### 🎸 AI指摘事項 🎹

<Details><Summary>Review by ClaudeAI and ChatGPT</Summary>

```ts
本PRでは指摘事項なし
```

</Details>

### 💻 評価項目 🆚

<!-- 行った動作確認を箇条書きでも -->

- 

### 🎵 備考 💚 Y(_ﾟ□ﾟ_) < (あれば)

<!-- ちょっとXXに課題が残っている...など何かあれば備忘のためにも -->

![PR-Foorter](https://capsule-render.vercel.app/api?type=slice&height=39&color=0:ffc096,100:99ccff&section=footer&reversal=false)
<!-- prettier-ignore-end -->
