### PR TITLE
fix: correct release-drafter template placeholder

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -27,4 +27,4 @@ change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add
 template: |
   ## 🌻 What's New > (￣△￣*)
 
-  $CATEGORIES
+  $CHANGES


### PR DESCRIPTION
## Summary
- release-drafter.ymlのtemplateで`$CATEGORIES`を`$CHANGES`に修正
- `$CATEGORIES`は存在しないプレースホルダーのため、リリースノートが正しく生成されなかった

## Test plan
- [ ] PRマージ後、release/untitledへのPR作成時にリリースノートが正しく生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)