### PR TITLE
fix: trigger release-draft on push instead of pull_request

### DIFF
--- a/.github/workflows/create-release-note.yml
+++ b/.github/workflows/create-release-note.yml
@@ -158,7 +158,7 @@ jobs:
 
   release-draft:
     needs: check-version
-    if: needs.check-version.outputs.version_changed == 'true' && github.event_name == 'pull_request'
+    if: needs.check-version.outputs.version_changed == 'true' && github.event_name == 'push'
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
## Summary
- release-draftジョブのトリガーを`pull_request`から`push`に変更
- release-drafterはマージ済みのPRを収集するため、PRマージ後（pushイベント）に実行する必要がある

## Test plan
- [ ] release/untitledへのPRマージ後にリリースノートが正しく生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)